### PR TITLE
Propagate changes to zinc image functions

### DIFF
--- a/source/command/cmiss.cpp
+++ b/source/command/cmiss.cpp
@@ -2644,10 +2644,12 @@ Currently limited to 1 byte per component.
 			image_depth, storage, number_of_bytes_per_component, field_name))
 		{
 			bytes_per_pixel = number_of_components*number_of_bytes_per_component;
+			double texture_width, texture_height, texture_depth;
+			Texture_get_physical_size(texture, &texture_width, &texture_height, &texture_depth);
 			Set_cmiss_field_value_to_texture(field, texture_coordinate_field,
-				texture, spectrum,	fail_material, image_height, image_width, image_depth,
-				bytes_per_pixel, number_of_bytes_per_component, use_pixel_location,
-				storage,propagate_field, Graphics_buffer_package_get_core_package(graphics_buffer_package), search_mesh);
+				texture, spectrum,	fail_material, image_width, image_height, image_depth,
+				bytes_per_pixel, number_of_bytes_per_component, use_pixel_location, texture_width, texture_height, texture_depth,
+				storage, propagate_field, Graphics_buffer_package_get_core_package(graphics_buffer_package), search_mesh);
 		}
 		else
 		{


### PR DESCRIPTION
Remove native_texture field on image. Fix bug where texture coordinates were overridden for image created from image source.
