### PR TITLE
Recover subelement handling mode for cmiss_selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ ENDIF( WIN32_USER_INTERFACE AND WIN32 )
 # Find our friendly Zinc CMake config file.
 # We can only use the static version of the library for the Cmgui application
 SET( ZINC_USE_STATIC TRUE )
+SET( REQUIRE_INTERNAL_ZINC_INCLUDE_DIR TRUE )
 FIND_PACKAGE( Zinc REQUIRED )
 
 IF( MSVC )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,14 @@ set(CMGUI_CMAKE_MODULE_PATH "" CACHE STRING "Location of OpenCMISS CMake modules
 if (DEFINED OPENCMISS_CMAKE_MODULE_PATH)
     set(CMGUI_CMAKE_MODULE_PATH "${OPENCMISS_CMAKE_MODULE_PATH}" CACHE STRING "Location of OpenCMISS CMake modules." FORCE)
 endif ()
-if (NOT EXISTS "${CMGUI_CMAKE_MODULE_PATH}/Modules/OpenCMISS/OCMiscFunctions.cmake")
-    message(FATAL_ERROR "'${CMGUI_CMAKE_MODULE_PATH}/Modules/OpenCMISS/OCMiscFunctions.cmake' does not exists.  The OpenCMISS CMake modules may not be installed/available.")
+if (NOT EXISTS "${CMGUI_CMAKE_MODULE_PATH}/OpenCMISS/OCMiscFunctions.cmake")
+    message(FATAL_ERROR "'${CMGUI_CMAKE_MODULE_PATH}/OpenCMISS/OCMiscFunctions.cmake' does not exists.  The OpenCMISS CMake modules may not be installed/available.")
 endif ()
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMGUI_CMAKE_MODULE_PATH}/FindModuleWrappers")
-list(APPEND CMAKE_MODULE_PATH "${CMGUI_CMAKE_MODULE_PATH}/Modules")
-list(APPEND CMAKE_MODULE_PATH "${CMGUI_CMAKE_MODULE_PATH}/Modules/OpenCMISS")
+list(APPEND CMAKE_MODULE_PATH "${CMGUI_CMAKE_MODULE_PATH}")
+list(APPEND CMAKE_MODULE_PATH "${CMGUI_CMAKE_MODULE_PATH}/OpenCMISS")
 
 INCLUDE( FunctionDefinitions )
 

--- a/source/command/cmiss.cpp
+++ b/source/command/cmiss.cpp
@@ -6203,8 +6203,9 @@ Executes a GFX EDIT GRAPHICS_OBJECT command.
 						for (int i = 0; (i < 2) && return_code; ++i)
 						{
 							cmzn_nodeset_id nodeset = cmzn_fieldmodule_find_nodeset_by_field_domain_type(fieldmodule, domainTypes[i]);
-							if (!cmzn_nodeset_assign_field_from_source(nodeset, rc_coordinate_field,
-								transformed_rc_coordinate_field, /*conditional_field*/0, time))
+							const int result = cmzn_nodeset_assign_field_from_source(nodeset, rc_coordinate_field,
+								transformed_rc_coordinate_field, /*conditional_field*/0, time);
+							if ((CMZN_RESULT_OK != result) && (CMZN_RESULT_WARNING_PART_DONE != result))
 							{
 								display_message(ERROR_MESSAGE, "gfx edit graphics_object:  Failed to apply transformation");
 								return_code = 0;
@@ -8181,8 +8182,12 @@ int gfx_evaluate(struct Parse_state *state, void *dummy_to_be_modified,
 							}
 							if (nodeset)
 							{
-								return_code = cmzn_nodeset_assign_field_from_source(nodeset, destination_field, source_field,
+								const int result = cmzn_nodeset_assign_field_from_source(nodeset, destination_field, source_field,
 									/*conditional_field*/selection_field, time);
+								if ((CMZN_RESULT_OK != result) && (CMZN_RESULT_WARNING_PART_DONE != result))
+								{
+									return_code = 0;
+								}
 								cmzn_nodeset_destroy(&nodeset);
 							}
 						}

--- a/source/graphics/scene_app.cpp
+++ b/source/graphics/scene_app.cpp
@@ -724,20 +724,28 @@ static cmzn_scene_id cmzn_scene_get_parent_scene_internal(cmzn_scene_id scene)
 cmzn_field_group_id cmzn_scene_get_selection_group(cmzn_scene_id scene)
 {
 	if (!scene)
+	{
 		return 0;
+	}
 	cmzn_field_group_id selection_group = scene->selection_group;
 	if (selection_group)
+	{
 		cmzn_field_access(cmzn_field_group_base_cast(selection_group));
+	}
 	return selection_group;
 }
 
 cmzn_field_group_id cmzn_scene_get_or_create_selection_group(cmzn_scene_id scene)
 {
 	if (!scene)
+	{
 		return 0;
+	}
 	cmzn_field_group_id selection_group = scene->selection_group;
 	if (selection_group)
+	{
 		cmzn_field_access(cmzn_field_group_base_cast(selection_group));
+	}
 	else
 	{
 		cmzn_scene_id parent_scene = cmzn_scene_get_parent_scene_internal(scene);
@@ -746,15 +754,18 @@ cmzn_field_group_id cmzn_scene_get_or_create_selection_group(cmzn_scene_id scene
 			cmzn_field_group_id parent_selection_group = cmzn_scene_get_or_create_selection_group(parent_scene);
 			selection_group = cmzn_field_group_get_subregion_field_group(parent_selection_group, scene->region);
 			if (!selection_group)
+			{
 				selection_group = cmzn_field_group_create_subregion_field_group(parent_selection_group, scene->region);
+			}
 			cmzn_field_group_destroy(&parent_selection_group);
 		}
 		else
 		{
 			// find by name or create
 			const char *default_selection_group_name = "cmiss_selection";
-			cmzn_fieldmodule_id field_module = cmzn_region_get_fieldmodule(scene->region);
-			cmzn_field_id field = cmzn_fieldmodule_find_field_by_name(field_module, default_selection_group_name);
+			cmzn_fieldmodule_id fieldmodule = cmzn_region_get_fieldmodule(scene->region);
+			cmzn_fieldmodule_begin_change(fieldmodule);
+			cmzn_field_id field = cmzn_fieldmodule_find_field_by_name(fieldmodule, default_selection_group_name);
 			if (field)
 			{
 				selection_group = cmzn_field_cast_group(field);
@@ -762,16 +773,19 @@ cmzn_field_group_id cmzn_scene_get_or_create_selection_group(cmzn_scene_id scene
 			}
 			if (!selection_group)
 			{
-				field = cmzn_fieldmodule_create_field_group(field_module);
+				field = cmzn_fieldmodule_create_field_group(fieldmodule);
 				cmzn_field_set_name(field, default_selection_group_name);
 				selection_group = cmzn_field_cast_group(field);
-				cmzn_field_group_set_subelement_handling_mode(selection_group, CMZN_FIELD_GROUP_SUBELEMENT_HANDLING_MODE_FULL);
 				cmzn_field_destroy(&field);
 			}
-			cmzn_fieldmodule_destroy(&field_module);
+			cmzn_field_group_set_subelement_handling_mode(selection_group, CMZN_FIELD_GROUP_SUBELEMENT_HANDLING_MODE_FULL);
+			cmzn_fieldmodule_end_change(fieldmodule);
+			cmzn_fieldmodule_destroy(&fieldmodule);
 		}
 		if (selection_group)
+		{
 			cmzn_scene_set_selection_field(scene, cmzn_field_group_base_cast(selection_group));
+		}
 	}
 	return selection_group;
 }


### PR DESCRIPTION
With this minor fix, if cmiss_selection group is saved to file, the selection group, on re-discovery by name, will have the expected subelement handling, i.e. it will add faces, lines and nodes to related subgroups.