### PR TITLE
Zincfixes

### DIFF
--- a/source/command/cmiss.cpp
+++ b/source/command/cmiss.cpp
@@ -2614,7 +2614,7 @@ Currently limited to 1 byte per component.
 
 		if (texture_coordinate_field &&
 			(3 >= (tex_number_of_components =
-			Computed_field_get_number_of_components(texture_coordinate_field))))
+			cmzn_field_get_number_of_components(texture_coordinate_field))))
 		{
 			return_code = 1;
 		}

--- a/source/computed_field/computed_field_arithmetic_operators_app.cpp
+++ b/source/computed_field/computed_field_arithmetic_operators_app.cpp
@@ -13,6 +13,7 @@
 #include "computed_field/computed_field_set.h"
 #include "computed_field/computed_field_set_app.h"
 #include "computed_field/computed_field_arithmetic_operators.h"
+#include "opencmiss/zinc/fieldarithmeticoperators.h"
 
 class Computed_field_arithmetic_operators_package : public Computed_field_type_package
 {
@@ -57,35 +58,35 @@ int Computed_field_get_type_sqrt(struct Computed_field *field,
 int Computed_field_get_type_log(struct Computed_field *field,
 	struct Computed_field **source_field);
 
-Computed_field *Computed_field_create_edit_mask(cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field, double *edit_mask);
+cmzn_field *cmzn_fieldmodule_create_field_edit_mask(cmzn_fieldmodule *field_module,
+	cmzn_field *source_field, double *edit_mask);
 
 int Computed_field_get_type_edit_mask(struct Computed_field *field,
 	struct Computed_field **source_field, double **edit_mask);
 
-Computed_field *Computed_field_create_offset(cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field, double *offsets);
+cmzn_field *cmzn_fieldmodule_create_field_offset(cmzn_fieldmodule *fieldmodule,
+	cmzn_field *source_field, double *offsets);
 
 int Computed_field_get_type_offset(struct Computed_field *field,
 	struct Computed_field **source_field, double **offsets);
 
-Computed_field *Computed_field_create_clamp_minimum(cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field, double *minimums);
+cmzn_field *cmzn_fieldmodule_create_field_clamp_maximum(cmzn_fieldmodule *fieldmodule,
+	cmzn_field *source_field, double *maximums);
 
 int Computed_field_get_type_clamp_minimum(struct Computed_field *field,
 	struct Computed_field **source_field, double **minimums);
 
-Computed_field *Computed_field_create_clamp_maximum(cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field, double *maximums);
+cmzn_field *cmzn_fieldmodule_create_field_clamp_minimum(cmzn_fieldmodule *fieldmodule,
+	cmzn_field *source_field, double *minimums);
 
 int Computed_field_get_type_clamp_maximum(struct Computed_field *field,
 	struct Computed_field **source_field, double **maximums);
 
-Computed_field *Computed_field_create_scale(cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field, double *scale_factors);
+cmzn_field *cmzn_fieldmodule_create_field_scale(cmzn_fieldmodule *field_module,
+	cmzn_field *source_field, double *scale_factors);
 
-int Computed_field_get_type_scale(struct Computed_field *field,
-	struct Computed_field **source_field, double **scale_factors);
+int Computed_field_get_type_scale(cmzn_field *field,
+	cmzn_field **source_field, double **scale_factors);
 
 int Computed_field_get_type_power(struct Computed_field *field,
 	struct Computed_field **source_field_one,
@@ -99,9 +100,13 @@ int Computed_field_get_type_divide_components(struct Computed_field *field,
 	struct Computed_field **source_field_one,
 	struct Computed_field **source_field_two);
 
-int Computed_field_get_type_add(struct Computed_field *field,
-	struct Computed_field **source_field_one, FE_value *scale_factor1,
-	struct Computed_field **source_field_two, FE_value *scale_factor2);
+cmzn_field *cmzn_fieldmodule_create_field_weighted_add(cmzn_fieldmodule *fieldmodule,
+	cmzn_field *source_field_one, double scale_factor1,
+	cmzn_field *source_field_two, double scale_factor2);
+
+int Computed_field_get_type_weighted_add(cmzn_field *field,
+	cmzn_field **source_field_one, FE_value *scale_factor1,
+	cmzn_field **source_field_two, FE_value *scale_factor2);
 
 int define_Computed_field_type_power(struct Parse_state *state,
 	void *field_modify_void,void *computed_field_arithmetic_operators_package_void)
@@ -166,7 +171,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_power(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_power(field_modify->get_field_module(),
 							source_fields[0], source_fields[1]));
 				}
 				if (!return_code)
@@ -273,7 +278,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_multiply(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_multiply(field_modify->get_field_module(),
 							source_fields[0], source_fields[1]));
 				}
 				if (!return_code)
@@ -380,7 +385,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_divide(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_divide(field_modify->get_field_module(),
 							source_fields[0], source_fields[1]));
 				}
 				if (!return_code)
@@ -462,7 +467,7 @@ already) and allows its contents to be modified.
 				(computed_field_add_type_string ==
 					Computed_field_get_type_string(field_modify->get_field())))
 			{
-				return_code=Computed_field_get_type_add(field_modify->get_field(),
+				return_code=Computed_field_get_type_weighted_add(field_modify->get_field(),
 					source_fields, scale_factors,
 					source_fields + 1, scale_factors + 1);
 			}
@@ -496,7 +501,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_weighted_add(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_weighted_add(field_modify->get_field_module(),
 							source_fields[0], scale_factors[0],
 							source_fields[1], scale_factors[1]));
 				}
@@ -669,7 +674,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_scale(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_scale(field_modify->get_field_module(),
 						source_field, scale_factors));
 			}
 			if (!return_code)
@@ -824,7 +829,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_clamp_maximum(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_clamp_maximum(field_modify->get_field_module(),
 						source_field, maximums));
 			}
 			if (!return_code)
@@ -977,7 +982,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_clamp_minimum(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_clamp_minimum(field_modify->get_field_module(),
 						source_field, minimums));
 			}
 			if (!return_code)
@@ -1133,7 +1138,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_offset(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_offset(field_modify->get_field_module(),
 						source_field, offsets));
 			}
 			if (!return_code)
@@ -1285,7 +1290,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_edit_mask(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_edit_mask(field_modify->get_field_module(),
 						source_field, edit_mask));
 			}
 			if (!return_code)
@@ -1377,7 +1382,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_log(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_log(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)
@@ -1476,7 +1481,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_sqrt(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_sqrt(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)
@@ -1575,7 +1580,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_exp(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_exp(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)
@@ -1673,7 +1678,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_abs(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_abs(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)

--- a/source/computed_field/computed_field_compose_app.cpp
+++ b/source/computed_field/computed_field_compose_app.cpp
@@ -19,10 +19,10 @@
 // insert app headers here
 #include "mesh/cmiss_element_private_app.hpp"
 
-Computed_field *Computed_field_create_compose(cmzn_fieldmodule *field_module,
-	struct Computed_field *texture_coordinate_field,
-	struct Computed_field *find_element_xi_field,
-	struct Computed_field *calculate_values_field,
+cmzn_field *cmzn_fieldmodule_create_field_compose(cmzn_fieldmodule *fieldmodule,
+	cmzn_field *texture_coordinate_field,
+	cmzn_field *find_element_xi_field,
+	cmzn_field *calculate_values_field,
 	cmzn_mesh_id search_mesh,
 	int find_nearest, int use_point_five_when_out_of_bounds);
 
@@ -219,7 +219,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_compose(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_compose(field_modify->get_field_module(),
 						texture_coordinates_field, find_element_xi_field,
 						calculate_values_field, mesh,
 						find_nearest, use_point_five_when_out_of_bounds));

--- a/source/computed_field/computed_field_composite_app.cpp
+++ b/source/computed_field/computed_field_composite_app.cpp
@@ -312,7 +312,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_composite(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_composite(field_modify->get_field_module(),
 						source_data.number_of_components,
 						source_data.number_of_source_fields, source_data.source_fields,
 						source_data.number_of_source_values, source_data.source_values,
@@ -458,7 +458,7 @@ and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_constant(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_constant(field_modify->get_field_module(),
 							number_of_values, values));
 				}
 				DESTROY(Option_table)(&option_table);

--- a/source/computed_field/computed_field_conditional_app.cpp
+++ b/source/computed_field/computed_field_conditional_app.cpp
@@ -97,7 +97,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_if(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_if(field_modify->get_field_module(),
 							source_fields[0], source_fields[1], source_fields[2]));
 				}
 				if (!return_code)

--- a/source/computed_field/computed_field_deformation_app.cpp
+++ b/source/computed_field/computed_field_deformation_app.cpp
@@ -20,16 +20,16 @@ class Computed_field_deformation_package : public Computed_field_type_package
 
 char computed_field_2d_strain_type_string[] = "2d_strain";
 
+cmzn_field *cmzn_fieldmodule_create_field_2d_strain(
+	cmzn_fieldmodule *fieldmodule,
+	cmzn_field *deformed_coordinate_field,
+	cmzn_field *undeformed_coordinate_field,
+	cmzn_field *fibre_angle_field);
+
 int Computed_field_get_type_2d_strain(struct Computed_field *field,
 	struct Computed_field **deformed_coordinate_field,
 	struct Computed_field **undeformed_coordinate_field,
 	struct Computed_field **fibre_angle_field);
-
-struct Computed_field *Computed_field_create_2d_strain(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *deformed_coordinate_field,
-	struct Computed_field *undeformed_coordinate_field,
-	struct Computed_field *fibre_angle_field);
 
 int define_Computed_field_type_2d_strain(struct Parse_state *state,
 	void *field_modify_void,void *computed_field_deformation_package_void)
@@ -114,7 +114,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_2d_strain(
+					cmzn_fieldmodule_create_field_2d_strain(
 						field_modify->get_field_module(),
 						deformed_coordinate_field, undeformed_coordinate_field,
 						fibre_angle_field));

--- a/source/computed_field/computed_field_finite_element_app.cpp
+++ b/source/computed_field/computed_field_finite_element_app.cpp
@@ -49,11 +49,11 @@ int Computed_field_get_type_embedded(struct Computed_field *field,
 	struct Computed_field **source_field_address,
 	struct Computed_field **embedded_location_field_address);
 
-struct Computed_field *Computed_field_create_finite_element_internal(
+cmzn_field *cmzn_fieldmodule_create_field_finite_element_internal(
 	struct cmzn_fieldmodule *field_module, struct FE_field *fe_field);
 
-struct Computed_field *Computed_field_create_access_count(
-	struct cmzn_fieldmodule *field_module);
+cmzn_field *cmzn_fieldmodule_create_field_access_count(
+	cmzn_fieldmodule *fieldmodule);
 
 cmzn_field_id cmzn_fieldmodule_create_field_basis_derivative(
 	cmzn_fieldmodule_id field_module, cmzn_field_id finite_element_field,
@@ -308,7 +308,7 @@ FE_field being made and/or modified.
 							}
 						}
 						return_code = field_modify->update_field_and_deaccess(
-							Computed_field_create_finite_element_internal(field_module, fe_field));
+							cmzn_fieldmodule_create_field_finite_element_internal(field_module, fe_field));
 					}
 					else
 					{
@@ -366,7 +366,7 @@ Converts <field> into type COMPUTED_FIELD_CMZN_NUMBER.
 		if (!state->current_token)
 		{
 			return_code = field_modify->update_field_and_deaccess(
-				Computed_field_create_cmiss_number(field_modify->get_field_module()));
+				cmzn_fieldmodule_create_field_cmiss_number(field_modify->get_field_module()));
 		}
 		else
 		{
@@ -412,7 +412,7 @@ Converts <field> into type COMPUTED_FIELD_ACCESS_COUNT.
 		if (!state->current_token)
 		{
 			return_code = field_modify->update_field_and_deaccess(
-				Computed_field_create_access_count(field_modify->get_field_module()));
+				cmzn_fieldmodule_create_field_access_count(field_modify->get_field_module()));
 		}
 		else
 		{
@@ -860,7 +860,7 @@ Converts <field> into type COMPUTED_FIELD_XI_COORDINATES.
 		if (!state->current_token)
 		{
 			return_code = field_modify->update_field_and_deaccess(
-				Computed_field_create_xi_coordinates(field_modify->get_field_module()));
+				cmzn_fieldmodule_create_field_xi_coordinates(field_modify->get_field_module()));
 		}
 		else
 		{

--- a/source/computed_field/computed_field_format_output_app.cpp
+++ b/source/computed_field/computed_field_format_output_app.cpp
@@ -75,7 +75,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_format_output(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_format_output(field_modify->get_field_module(),
 						source_field, format_string));
 			}
 			if (!return_code)

--- a/source/computed_field/computed_field_function_app.cpp
+++ b/source/computed_field/computed_field_function_app.cpp
@@ -118,7 +118,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_function(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_function(field_modify->get_field_module(),
 						source_field, result_field, reference_field));
 			}
 			if (!return_code)

--- a/source/computed_field/computed_field_integration_app.cpp
+++ b/source/computed_field/computed_field_integration_app.cpp
@@ -86,7 +86,7 @@ and allows its contents to be modified.
 			// use temporary field module to supply different defaults
 			cmzn_fieldmodule *temp_field_module = cmzn_region_get_fieldmodule(region);
 			cmzn_fieldmodule_set_field_name(temp_field_module, "constant_1.0");
-			integrand = Computed_field_create_constant(temp_field_module,
+			integrand = cmzn_fieldmodule_create_field_constant(temp_field_module,
 				/*number_of_components*/1, &value);
 			if (NULL == integrand)
 			{
@@ -183,7 +183,7 @@ and allows its contents to be modified.
 			else
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_integration(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_integration(field_modify->get_field_module(),
 						mesh, seed_element, integrand, magnitude_coordinates_flag, coordinate_field));
 			}
 		}
@@ -292,7 +292,7 @@ and allows its contents to be modified.
 		double value = 1.0;
 		cmzn_fieldmodule *temp_field_module = cmzn_region_get_fieldmodule(region);
 		cmzn_fieldmodule_set_field_name(temp_field_module, "constant_1.0");
-		Computed_field *integrand = Computed_field_create_constant(temp_field_module,
+		Computed_field *integrand = cmzn_fieldmodule_create_field_constant(temp_field_module,
 			/*number_of_components*/1, &value);
 		cmzn_fieldmodule_destroy(&temp_field_module);
 		if (NULL == integrand)
@@ -304,7 +304,7 @@ and allows its contents to be modified.
 		if (return_code)
 		{
 			return_code = field_modify->update_field_and_deaccess(
-				Computed_field_create_integration(field_modify->get_field_module(),
+				cmzn_fieldmodule_create_field_integration(field_modify->get_field_module(),
 					mesh, seed_element, integrand, /*magnitude_coordinates*/0, coordinate_field));
 		}
 		if (group_name)

--- a/source/computed_field/computed_field_lookup_app.cpp
+++ b/source/computed_field/computed_field_lookup_app.cpp
@@ -224,7 +224,7 @@ contents to be modified.
 			if (node)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_quaternion_SLERP(field_modify->get_field_module(),
+					cmzn_fieldmodule_create_field_quaternion_SLERP(field_modify->get_field_module(),
 						source_field, node));
 			}
 			else

--- a/source/computed_field/computed_field_matrix_operators_app.cpp
+++ b/source/computed_field/computed_field_matrix_operators_app.cpp
@@ -62,17 +62,11 @@ int Computed_field_get_type_eigenvectors(struct Computed_field *field,
 int Computed_field_get_type_eigenvalues(struct Computed_field *field,
 	struct Computed_field **source_field);
 
-Computed_field *Computed_field_create_quaternion_to_matrix(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field);
+cmzn_field *cmzn_fieldmodule_create_field_matrix_to_quaternion(
+	cmzn_fieldmodule *fieldmodule, cmzn_field *source_field);
 
-Computed_field *Computed_field_create_quaternion_to_matrix(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field);
-
-Computed_field *Computed_field_create_matrix_to_quaternion(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field);
+cmzn_field *cmzn_fieldmodule_create_field_quaternion_to_matrix(
+	cmzn_fieldmodule *fieldmodule, cmzn_field *source_field);
 
 int Computed_field_is_type_eigenvalues_conditional(struct Computed_field *field,
 	void *dummy_void);
@@ -755,7 +749,7 @@ Converts a "quaternion" to a transformation matrix.
 					if (return_code)
 					{
 						return_code = field_modify->update_field_and_deaccess(
-							Computed_field_create_quaternion_to_matrix(
+							cmzn_fieldmodule_create_field_quaternion_to_matrix(
 								field_modify->get_field_module(), source_fields[0]));
 					}
 					else
@@ -854,7 +848,7 @@ Converts a transformation matrix to  a "quaternion".
 					if (return_code)
 					{
 						return_code = field_modify->update_field_and_deaccess(
-							Computed_field_create_matrix_to_quaternion(
+							cmzn_fieldmodule_create_field_matrix_to_quaternion(
 								field_modify->get_field_module(), source_fields[0]));
 					}
 					else

--- a/source/computed_field/computed_field_scene_viewer_projection_app.cpp
+++ b/source/computed_field/computed_field_scene_viewer_projection_app.cpp
@@ -54,7 +54,7 @@ int Computed_field_get_type_scene_viewer_projection(struct Computed_field *field
 	enum cmzn_scenecoordinatesystem *to_coordinate_system);
 
 /* For gfx command */
-struct Computed_field *Computed_field_create_scene_viewer_projection_with_window_name(
+cmzn_field *cmzn_fieldmodule_create_field_scene_viewer_projection_with_window_name(
 	struct cmzn_fieldmodule *field_module, struct Scene_viewer *scene_viewer,
 	const char *graphics_window_name, int pane_number,
 	enum cmzn_scenecoordinatesystem from_coordinate_system,
@@ -70,7 +70,7 @@ struct Computed_field *Computed_field_create_scene_viewer_projection_with_window
 	else
 	{
 		display_message(ERROR_MESSAGE,
-			"Computed_field_create_scene_viewer_projection.  Invalid argument(s)");
+			"cmzn_fieldmodule_create_field_scene_viewer_projection_with_window_name.  Invalid argument(s)");
 	}
 
 	return (field);
@@ -212,7 +212,7 @@ already) and allows its contents to be modified.
 			{
 				GET_NAME(Graphics_window)(graphics_window, &graphics_window_name);
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_scene_viewer_projection_with_window_name(
+					cmzn_fieldmodule_create_field_scene_viewer_projection_with_window_name(
 						field_modify->get_field_module(),
 						scene_viewer->core_scene_viewer, graphics_window_name, pane_number - 1,
 						from_coordinate_system, to_coordinate_system));

--- a/source/computed_field/computed_field_set_app.cpp
+++ b/source/computed_field/computed_field_set_app.cpp
@@ -98,7 +98,7 @@ wrapper for field and add it to the manager.
 							Computed_field_manager_get_region(set_field_data->computed_field_manager);
 						cmzn_fieldmodule *temp_field_module = cmzn_region_get_fieldmodule(region);
 						cmzn_fieldmodule_set_field_name(temp_field_module, "constants");
-						selected_field = Computed_field_create_constant(temp_field_module,
+						selected_field = cmzn_fieldmodule_create_field_constant(temp_field_module,
 							number_of_values, values);
 						cmzn_fieldmodule_destroy(&temp_field_module);
 

--- a/source/computed_field/computed_field_trigonometry_app.cpp
+++ b/source/computed_field/computed_field_trigonometry_app.cpp
@@ -113,7 +113,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_sin(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_sin(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)
@@ -212,7 +212,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_cos(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_cos(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)
@@ -311,7 +311,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_tan(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_tan(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)
@@ -410,7 +410,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_asin(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_asin(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)
@@ -509,7 +509,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_acos(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_acos(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)
@@ -608,7 +608,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_atan(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_atan(field_modify->get_field_module(),
 							source_fields[0]));
 				}
 				if (!return_code)
@@ -713,7 +713,7 @@ already) and allows its contents to be modified.
 				if (return_code)
 				{
 					return_code = field_modify->update_field_and_deaccess(
-						Computed_field_create_atan2(field_modify->get_field_module(),
+						cmzn_fieldmodule_create_field_atan2(field_modify->get_field_module(),
 							source_fields[0], source_fields[1]));
 				}
 				if (!return_code)

--- a/source/computed_field/computed_field_trigonometry_app.h
+++ b/source/computed_field/computed_field_trigonometry_app.h
@@ -4,37 +4,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
-
-
-Computed_field *Computed_field_create_sin(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field);
-
-Computed_field *Computed_field_create_cos(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field);
-
-Computed_field *Computed_field_create_tan(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field);
-
-Computed_field *Computed_field_create_asin(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field);
-
-Computed_field *Computed_field_create_acos(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field);
-
-Computed_field *Computed_field_create_atan(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field);
-
-Computed_field *Computed_field_create_atan2(
-	struct cmzn_fieldmodule *field_module,
-	struct Computed_field *source_field_one,
-	struct Computed_field *source_field_two);
+#include "opencmiss/zinc/fieldtrigonometry.h"
 
 int Computed_field_register_types_trigonometry(
 	struct Computed_field_package *computed_field_package);

--- a/source/computed_field/computed_field_vector_operators_app.cpp
+++ b/source/computed_field/computed_field_vector_operators_app.cpp
@@ -44,8 +44,8 @@ int Computed_field_get_type_magnitude(struct Computed_field *field,
 int Computed_field_get_type_cubic_texture_coordinates(struct Computed_field *field,
 	struct Computed_field **source_field);
 
-struct Computed_field *Computed_field_create_cubic_texture_coordinates(
-	struct cmzn_fieldmodule *field_module,
+cmzn_field *cmzn_fieldmodule_create_field_cubic_texture_coordinates(
+	struct cmzn_fieldmodule *fieldmodule,
 	struct Computed_field *source_field);
 
 int define_Computed_field_type_normalise(struct Parse_state *state,
@@ -707,7 +707,7 @@ already) and allows its contents to be modified.
 			if (return_code)
 			{
 				return_code = field_modify->update_field_and_deaccess(
-					Computed_field_create_cubic_texture_coordinates(
+					cmzn_fieldmodule_create_field_cubic_texture_coordinates(
 						field_modify->get_field_module(), source_field));
 			}
 			if (!return_code)

--- a/source/element/element_point_viewer_wx.cpp
+++ b/source/element/element_point_viewer_wx.cpp
@@ -778,7 +778,7 @@ static char *element_point_viewer_get_field_string(struct Element_point_viewer *
 	FE_value time, *xi;
 	struct FE_element *element,*top_level_element;
 
-	int number_of_components = Computed_field_get_number_of_components(field);
+	int number_of_components = cmzn_field_get_number_of_components(field);
 	if (element_point_viewer &&
 		(element = element_point_viewer->element_point_identifier.element) &&
 		(top_level_element = element_point_viewer->element_point_identifier.top_level_element) &&
@@ -2272,7 +2272,7 @@ pass unmanaged elements in the element_point_identifier to this widget.
 // 				(!(element_point_viewer->element_point_identifier.element))||
 // 				(field != element_point_viewer->current_field)||
 // 				(field&&((element_point_viewer->number_of_components !=
-// 							Computed_field_get_number_of_components(field))||
+// 							cmzn_field_get_number_of_components(field))||
 // 					 (new_editable != old_editable))))
 // 		 {
 				setup_components=1;
@@ -2391,7 +2391,7 @@ Creates the array of cells containing field component names and values.
 				editable = element_point_field_is_editable(
 					 &(element_point_viewer->element_point_identifier),
 					 field,number_in_xi);
-				number_of_components=Computed_field_get_number_of_components(field);
+				number_of_components=cmzn_field_get_number_of_components(field);
 				element_point_viewer->number_of_components=number_of_components;
 				for (comp_no=0;(comp_no<number_of_components)&&return_code;comp_no++)
 				{

--- a/source/node/node_tool.cpp
+++ b/source/node/node_tool.cpp
@@ -471,7 +471,7 @@ static int FE_node_calculate_delta_position(struct FE_node *node,
 
 	ENTER(FE_node_calculate_delta_position);
 	if (node && edit_info && edit_info->nodeset && edit_info->rc_coordinate_field &&
-		(3 >= Computed_field_get_number_of_components(edit_info->rc_coordinate_field)))
+		(3 >= cmzn_field_get_number_of_components(edit_info->rc_coordinate_field)))
 	{
 		return_code=1;
 		/* clear coordinates in case less than 3 dimensions */
@@ -608,7 +608,7 @@ static int FE_node_edit_position(struct FE_node *node,
 
 	ENTER(FE_node_edit_position);
 	if (node && edit_info && edit_info->nodeset && edit_info->rc_coordinate_field &&
-		(3 >= Computed_field_get_number_of_components(edit_info->rc_coordinate_field)))
+		(3 >= cmzn_field_get_number_of_components(edit_info->rc_coordinate_field)))
 	{
 		return_code=1;
 		/* the last_picked_node was edited in FE_node_calculate_delta_position.
@@ -674,11 +674,11 @@ NOTE: currently does not tolerate having a variable_scale_field.
 	ENTER(FE_node_calculate_delta_vector);
 	if (node&&(edit_info=(struct FE_node_edit_information *)edit_info_void)&&
 		edit_info->nodeset && edit_info->rc_coordinate_field &&
-		(3>=Computed_field_get_number_of_components(
+		(3>=cmzn_field_get_number_of_components(
 			edit_info->rc_coordinate_field))&&
 		edit_info->wrapper_orientation_scale_field&&
 		(0<(number_of_orientation_scale_components=
-			Computed_field_get_number_of_components(
+			cmzn_field_get_number_of_components(
 				edit_info->wrapper_orientation_scale_field)))&&
 		(9>=number_of_orientation_scale_components)&&
 		(0.0 == edit_info->glyph_centre[0])&&
@@ -790,7 +790,7 @@ NOTE: currently does not tolerate having a variable_scale_field.
 						number_of_orientation_scale_components, orientation_scale))
 					{
 						number_of_orientation_scale_components=
-							Computed_field_get_number_of_components(
+							cmzn_field_get_number_of_components(
 								edit_info->orientation_scale_field);
 						switch (number_of_orientation_scale_components)
 						{
@@ -887,7 +887,7 @@ static int FE_node_edit_vector(struct FE_node *node,
 	ENTER(FE_node_edit_vector);
 	if (node && edit_info && edit_info->nodeset && edit_info->orientation_scale_field &&
 		(0<(number_of_orientation_scale_components=
-			Computed_field_get_number_of_components(
+			cmzn_field_get_number_of_components(
 				edit_info->orientation_scale_field)))&&
 		(9>=number_of_orientation_scale_components))
 	{


### PR DESCRIPTION
Stop using #define to renaming public field APIs.
Dependent on opencmiss/zinc#150