### PR TITLE
Set wxWidgets options from FindPackage() variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,13 +71,8 @@ set(WIN32_USER_INTERFACE FALSE)
 if( WX_USER_INTERFACE )
     find_package( wxWidgets REQUIRED COMPONENTS xrc adv html gl xml core base )
     set( CAN_USE_USER_INTERFACE ${wxWidgets_FOUND} )
-
-    # Note: we should use `include(${wxWidgets_USE_FILE})` below except that
-    # the `FindwxWidgets.cmake` bundled with `opencmiss` incorrectly adds an
-    # extension of `cmake` to the file name (compare it with
-    # https://github.com/Kitware/CMake/blob/master/Modules/FindwxWidgets.cmake)
-
-    include(UsewxWidgets)
+    include_directories(${wxWidgets_INCLUDE_DIRS})
+    add_compile_definitions(${wxWidgets_DEFINITIONS})
 endif( WX_USER_INTERFACE )
 
 IF(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,10 @@ set(GTK_USER_INTERFACE FALSE)
 set(WIN32_USER_INTERFACE FALSE)
 
 if( WX_USER_INTERFACE )
-    find_package( wxWidgets REQUIRED COMPONENTS xrc adv html gl xml core base CONFIG)
+    find_package( wxWidgets REQUIRED COMPONENTS xrc adv html gl xml core base )
     set( CAN_USE_USER_INTERFACE ${wxWidgets_FOUND} )
+    include_directories(${wxWidgets_INCLUDE_DIRS})
+	add_compile_definitions(${wxWidgets_DEFINITIONS})
 endif( WX_USER_INTERFACE )
 
 IF(WIN32)
@@ -221,7 +223,7 @@ IF(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C
 ENDIF()
 
 target_include_directories(${CMGUI_TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/source ${CMAKE_CURRENT_BINARY_DIR}/source)
-target_link_libraries(${CMGUI_TARGET} zinc-static wxWidgets::aui wxWidgets::xrc wxWidgets::gl)
+target_link_libraries(${CMGUI_TARGET} zinc-static ${wxWidgets_LIBRARIES})
 if(USE_PERL_INTERPRETER)
 	target_link_libraries(${CMGUI_TARGET} cmiss_perl_interpreter)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,13 @@ set(WIN32_USER_INTERFACE FALSE)
 if( WX_USER_INTERFACE )
     find_package( wxWidgets REQUIRED COMPONENTS xrc adv html gl xml core base )
     set( CAN_USE_USER_INTERFACE ${wxWidgets_FOUND} )
-    include_directories(${wxWidgets_INCLUDE_DIRS})
-	add_compile_definitions(${wxWidgets_DEFINITIONS})
+
+    # Note: we should use `include(${wxWidgets_USE_FILE})` below except that
+    # the `FindwxWidgets.cmake` bundled with `opencmiss` incorrectly adds an
+    # extension of `cmake` to the file name (compare it with
+    # https://github.com/Kitware/CMake/blob/master/Modules/FindwxWidgets.cmake)
+
+    include(UsewxWidgets)
 endif( WX_USER_INTERFACE )
 
 IF(WIN32)


### PR DESCRIPTION
Here's what was needed to use `wxWidgets` via `FindPackage()`, which uses `FindwxWidgets.cmake` bundled with OpenCMISS, using the method recommended at https://docs.wxwidgets.org/trunk/overview_cmake.html.

The `CONFIG` option to `find_package()` fails with trying to use a missing `wxWidgetsConfig.cmake` or `wxwidgets-config.cmake`.